### PR TITLE
Remove sudo from docker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ make serve
 
 __Docker Build:__
 ```bash
-sudo docker build -t owasp-halifax .
+docker build -t owasp-halifax .
 ```
 
 __Docker Compose:__
 ```bash
-sudo docker-compose up .
+docker-compose up .
 ```
 
 # Contributing


### PR DESCRIPTION
On Linux, prefixing docker commands with `sudo` is a given and doesn't
need to be mentioned, it's not needed on macOS, and as far as I can
tell, not needed on Windows either.